### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
-
 env:
   UV_FROZEN: 1
 
@@ -26,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - uses: pre-commit/action@v3.0.1
         env:
@@ -52,7 +50,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - name: Build package
         run: uv build

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ help: Makefile  ## Show help
 # =============================================================================
 install:  ## Install the app locally
 	uv python install
-	uv sync --frozen --all-extras
+	uv sync --frozen
 	pre-commit install --install-hooks
 .PHONY: install
 
 update:  ## Update deps and tools
-	uv sync --upgrade --all-extras
+	uv sync --upgrade
 	pre-commit autoupdate
 .PHONY: update
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["typer>=0.15.1"]
 check-file-pair = "pre_commit_hooks.check_file_pair:entrypoint"
 preferred-suffix = "pre_commit_hooks.preferred_suffix:entrypoint"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["mypy~=1.16.0", "ruff~=0.12.1"]
 test = [
   "coverage~=7.9.1",
@@ -27,6 +27,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pre_commit_hooks"]
+
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [tool.ruff]
 target-version = "py39"

--- a/uv.lock
+++ b/uv.lock
@@ -230,7 +230,7 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "ruff" },
@@ -244,17 +244,20 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "coverage", marker = "extra == 'test'", specifier = "~=7.9.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.16.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "~=8.4.1" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = "~=6.2.1" },
-    { name = "pytest-env", marker = "extra == 'test'", specifier = "~=1.1.1" },
-    { name = "pytest-sugar", marker = "extra == 'test'", specifier = "~=1.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "~=0.12.1" },
-    { name = "typer", specifier = ">=0.15.1" },
+requires-dist = [{ name = "typer", specifier = ">=0.15.1" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = "~=1.16.0" },
+    { name = "ruff", specifier = "~=0.12.1" },
 ]
-provides-extras = ["dev", "test"]
+test = [
+    { name = "coverage", specifier = "~=7.9.1" },
+    { name = "pytest", specifier = "~=8.4.1" },
+    { name = "pytest-cov", specifier = "~=6.2.1" },
+    { name = "pytest-env", specifier = "~=1.1.1" },
+    { name = "pytest-sugar", specifier = "~=1.0.0" },
+]
 
 [[package]]
 name = "pygments"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.